### PR TITLE
Désactiver les recherches de logos en ligne lors de la génération des badges

### DIFF
--- a/serveur.py
+++ b/serveur.py
@@ -97,7 +97,14 @@ def admin_generate_badges_zip():
     archive_io = BytesIO()
     with zipfile.ZipFile(archive_io, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for index, participant in enumerate(participants, start=1):
-            svg_bytes = render_badge_svg(template_root, participant)
+            svg_bytes = render_badge_svg(
+                template_root,
+                participant,
+                # Les recherches de logos en ligne peuvent ralentir fortement
+                # la génération côté serveur et entraîner un "proxy error".
+                # On se limite donc aux logos locaux pour cette route.
+                allow_online_logo_lookup=False,
+            )
             archive.writestr(f"{badge_basename(participant, index)}.svg", svg_bytes)
 
     archive_io.seek(0)


### PR DESCRIPTION
## Summary
- désactive la recherche de logos Clearbit lors de la génération des badges via l'interface admin pour éviter les longs délais
- documente la raison dans le code pour les futures maintenances

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32473861c8324a55299b65484b0ca