### PR TITLE
Améliore l’export complet, les compteurs et les badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ d'identification individuels à partir d'un template SVG.
 
 Le fichier `static/ressources/badge_template.svg` sert de base à chaque badge.
 Il contient des éléments texte avec des identifiants (`id="company"`,
-`id="full_name"`, `id="role"`, `id="email"`). Deux zones `image` sont
+`id="name_line_1"`, `id="name_line_2"`, `id="role"`, `id="email"`). Deux zones `image` sont
 pré-configurées : `id="logo_geii"` pour le logo du département et
 `id="company_logo"` pour le logo de l'entreprise.
 
@@ -92,7 +92,7 @@ Depuis le tableau de bord (`/forum-metier/admin`), un bouton « Télécharger l
 Chaque badge reprend les informations suivantes :
 
 * **Entreprise** — Nom de l'organisation (`ent_nom`).
-* **Nom et prénom** — Combinaison des champs `pX_nom` et `pX_prenom`.
+* **Nom et prénom** — Les deux lignes `name_line_1` et `name_line_2` combinent les champs `pX_prenom` et `pX_nom`.
 * **Poste** — Valeur de `pX_poste` si fournie, sinon la mention « Poste ».
 * **Adresse e-mail** — Valeur de `pX_email`.
 

--- a/generate_badges.py
+++ b/generate_badges.py
@@ -73,22 +73,31 @@ class Participant:
     role: str
     email: str
 
-    @property
-    def full_name(self) -> str:
-        """Return the full name formatted for display on the badge."""
-
-        names = [self.first_name.strip(), self.last_name.strip()]
-        return " ".join(part for part in names if part)
-
     def as_mapping(self) -> Dict[str, str]:
         """Return a mapping used to update the SVG template."""
 
+        line1, line2 = self._name_lines()
         return {
             "company": self.company.strip() or "Entreprise",
-            "full_name": self.full_name or "Participant",
+            "name_line_1": line1,
+            "name_line_2": line2,
             "role": self.role.strip() or "Poste",  # fallback text
             "email": self.email.strip(),
         }
+
+    def _name_lines(self) -> Tuple[str, str]:
+        """Return the two lines used to display the participant's name."""
+
+        first = self.first_name.strip()
+        last = self.last_name.strip()
+
+        if first and last:
+            return first, last
+        if first:
+            return first, ""
+        if last:
+            return last, ""
+        return "Participant", ""
 
 
 def _to_text(value: Any) -> str:

--- a/static/ressources/badge_template.svg
+++ b/static/ressources/badge_template.svg
@@ -11,7 +11,7 @@
       .badge-background { fill: #ffffff; stroke: #009de0; stroke-width: 4; rx: 18; ry: 18; }
       .banner { fill: #009de0; }
       .company { font: 700 20px 'Arial', sans-serif; fill: #009de0; text-anchor: middle; }
-      .name { font: 700 32px 'Arial', sans-serif; fill: #3b1c13; text-anchor: middle; }
+      .name { font: 700 30px 'Arial', sans-serif; fill: #3b1c13; text-anchor: middle; }
       .role { font: 400 18px 'Arial', sans-serif; fill: #3b1c13; text-anchor: middle; }
       .email { font: 300 14px 'Arial', sans-serif; fill: #3b1c13; text-anchor: middle; }
     ]]></style>
@@ -21,7 +21,8 @@
   <image id="logo_geii" x="24" y="20" width="88" height="40" preserveAspectRatio="xMidYMid meet" visibility="hidden" />
   <image id="company_logo" x="240" y="20" width="88" height="40" preserveAspectRatio="xMidYMid meet" visibility="hidden" />
   <text id="company" class="company" x="176" y="78">Votre entreprise</text>
-  <text id="full_name" class="name" x="176" y="136">Nom Prénom</text>
-  <text id="role" class="role" x="176" y="172">Poste actuel</text>
-  <text id="email" class="email" x="176" y="198">prenom.nom@example.com</text>
+  <text id="name_line_1" class="name" x="176" y="132">Prénom</text>
+  <text id="name_line_2" class="name" x="176" y="164">Nom</text>
+  <text id="role" class="role" x="176" y="188">Poste actuel</text>
+  <text id="email" class="email" x="176" y="204">prenom.nom@example.com</text>
 </svg>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -160,14 +160,18 @@
       const companies=[];
 
       for(const r of rows){
+        const parcoursSet = parseParcours(r[COLS.parcours]);
+        const declaredRaw = r[COLS.nb];
+        const declared = Number.parseInt(declaredRaw, 10);
         const ent = {
           nom: r[COLS.ent_name],
           adresse: r[COLS.ent_addr],
           cp: r[COLS.ent_cp],
           ville: r[COLS.ent_ville],
           description: r[COLS.ent_desc],
-          parcours: parseParcours(r[COLS.parcours]),
-          personnes:[]
+          parcours: parcoursSet,
+          personnes:[],
+          nb_declares: Number.isFinite(declared) ? declared : null
         };
         // 3 personnes
         for(const base of ["p1","p2","p3"]){
@@ -182,9 +186,12 @@
             if(isOui(dej)) lunchYes++;
           }
         }
+        if(ent.nb_declares == null){
+          ent.nb_declares = ent.personnes.length;
+        }
         companies.push(ent);
         for(const p of ent.parcours){
-          companiesPerParcours[p]++; 
+          companiesPerParcours[p]++;
           peoplePerParcours[p]+=ent.personnes.length;
           groups[p].push(ent);
         }
@@ -236,7 +243,7 @@
           <td class="mono">${ent.cp||'—'}</td>
           <td>${ent.adresse||'—'}</td>
           <td style="white-space:pre-wrap">${ent.description||'—'}</td>
-          <td class="mono">${ent.nb_declares||0}</td>
+          <td class="mono">${fmt(ent.nb_declares||0)}</td>
           <td>${parcoursBadges||'—'}</td>`;
         tbody.appendChild(tr);
       }
@@ -310,10 +317,23 @@
 
     function exportPeopleFull(){
       if(!lastTotals) return;
-      const rows = [["Nom","Prénom","Poste","Email","Entreprise","Déj"]];
+      const rows = [["Nom","Prénom","Poste","Email","Entreprise","Adresse","Code postal","Ville","Description","Parcours","Personnes déclarées","Déj"]];
       for(const ent of lastTotals.companies){
         for(const p of ent.personnes){
-          rows.push([p.nom, p.prenom, p.poste, p.email, ent.nom, p.dejeuner]);
+          rows.push([
+            p.nom,
+            p.prenom,
+            p.poste,
+            p.email,
+            ent.nom,
+            ent.adresse,
+            ent.cp,
+            ent.ville,
+            ent.description,
+            Array.from(ent.parcours).sort().join(", "),
+            ent.nb_declares,
+            p.dejeuner
+          ]);
         }
       }
       downloadCSV('personnes_complet.csv', rows);


### PR DESCRIPTION
## Summary
- complète l’export CSV détaillé avec l’adresse et les autres informations d’entreprise
- corrige le compteur de personnes déclarées dans les tableaux par parcours
- met à jour le générateur de badges et le template SVG pour afficher prénom et nom sur deux lignes

## Testing
- python -m compileall .
- python generate_badges.py dump.csv static/ressources/badge_template.svg --output tmp_badges --formats svg

------
https://chatgpt.com/codex/tasks/task_e_68de3306dac08324af8f0c9d34e53d72